### PR TITLE
refactor: fix remaining old name references

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -1,5 +1,5 @@
 name: 'Build Debian Package'
-description: 'Build homarr-branding-halos package'
+description: 'Build halos-homarr-branding package'
 runs:
   using: 'composite'
   steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # Debian build directories
 debian/.debhelper/
-debian/homarr-branding-halos/
+debian/halos-homarr-branding/
 debian/debhelper-build-stamp
 debian/files
 debian/*.substvars


### PR DESCRIPTION
## Summary
Fix remaining references to the old package name that were missed in the initial rename PR.

## Changes
- `.github/actions/build-deb/action.yml` - Updated description from `homarr-branding-halos` to `halos-homarr-branding`
- `.gitignore` - Updated debian build directory path

## Related PRs
This is part of a coordinated rename across multiple repositories:
- hatlabs/halos-distro#50
- hatlabs/halos-core-containers#10
- hatlabs/homarr-container-adapter#6
- hatlabs/halos-metapackages#11

## Test plan
- [ ] PR checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)