### PR TITLE
ci: add workflow_dispatch trigger for manual builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: Main Branch CI/CD
 on:
   push:
     branches: [main]
+  workflow_dispatch:  # Allow manual triggering
 
 jobs:
   build-release:


### PR DESCRIPTION
## Summary
Add `workflow_dispatch` trigger to the main workflow, allowing manual builds from the GitHub Actions UI.

## Test plan
- [ ] After merge, verify "Run workflow" button appears in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)