### PR TITLE
fix: update dependency from homarr-container to halos-homarr-container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,5 +86,5 @@ The `branding.toml` file contains:
 
 ## Related Packages
 
-- **homarr-container** - The Homarr dashboard container
+- **halos-homarr-container** - The Homarr dashboard container
 - **homarr-container-adapter** - Reads this config and applies it via Homarr API

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package provides:
 
 ## Installation
 
-The package is installed as part of HaLOS images. It depends on `homarr-container`.
+The package is installed as part of HaLOS images. It depends on `halos-homarr-container`.
 
 ```bash
 apt install halos-homarr-branding
@@ -39,7 +39,7 @@ The main configuration file is installed at:
 
 ## How It Works
 
-1. `homarr-container` starts the Homarr dashboard
+1. `halos-homarr-container` starts the Homarr dashboard
 2. `homarr-container-adapter` detects first boot
 3. Adapter reads `/etc/halos-homarr-branding/branding.toml`
 4. Adapter completes Homarr onboarding via API:
@@ -70,7 +70,7 @@ The main configuration file is installed at:
 
 ## Related Packages
 
-- [homarr-container](../halos-core-containers/apps/homarr/) - Homarr dashboard container
+- [halos-homarr-container](../halos-core-containers/apps/homarr/) - Homarr dashboard container
 - [homarr-container-adapter](https://github.com/hatlabs/homarr-container-adapter) - First-boot setup and auto-discovery
 
 ## License

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Rules-Requires-Root: no
 Package: halos-homarr-branding
 Architecture: all
 Depends: ${misc:Depends},
-         homarr-container
+         halos-homarr-container
 Description: HaLOS branding and default configuration for Homarr dashboard
  This package provides the Hat Labs "HaLOS" branding configuration for
  the Homarr dashboard, including default theme colors, admin credentials,


### PR DESCRIPTION
## Summary

- Fix broken package dependency: `homarr-container` → `halos-homarr-container`
- The `halos-core-containers` build uses `--prefix halos`, so the generated package name is `halos-homarr-container`
- Update documentation references to match

## Test plan

- [ ] Verify `apt install halos` succeeds on test system
- [ ] Confirm halos-homarr-branding installs halos-homarr-container as dependency

🤖 Generated with [Claude Code](https://claude.ai/code)