### PR TITLE
feat: update default branding to Hat Labs colors and naming

### DIFF
--- a/etc/halos-homarr-branding/branding.toml
+++ b/etc/halos-homarr-branding/branding.toml
@@ -30,10 +30,10 @@ favicon_path = "/usr/share/halos-homarr-branding/favicon.ico"
 # Dark mode is preferred for marine/industrial environments
 default_color_scheme = "dark"
 
-# Primary color (Hat Labs navy)
+# Primary color
 primary_color = "#273f65"
 
-# Secondary color (Hat Labs burgundy)
+# Secondary color
 secondary_color = "#6d131e"
 
 # Item border radius: "xs", "sm", "md", "lg", "xl"


### PR DESCRIPTION
## Summary
- Update primary color to #273f65 (Hat Labs navy)
- Update secondary color to #6d131e (Hat Labs burgundy)
- Change board name from "halos-dashboard" to "Halos"
- Change display name from "HaLOS Dashboard" to "Halos"

## Test plan
- [ ] Deploy to test device and verify Homarr dashboard shows new colors
- [ ] Verify board is created with name "Halos"

🤖 Generated with [Claude Code](https://claude.com/claude-code)