### PR TITLE
fix(ci): add concurrency group to prevent race condition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:  # Allow manual triggering
 
+concurrency:
+  group: ${{ github.repository }}-main-release
+  cancel-in-progress: false
+
 jobs:
   build-release:
     uses: hatlabs/shared-workflows/.github/workflows/build-release.yml@main


### PR DESCRIPTION
## Summary
- Add concurrency group to the main CI workflow
- Prevents race conditions when multiple PRs are merged in quick succession
- Without this fix, concurrent runs could calculate the same revision number, causing one to fail

## Test plan
- [ ] Verify CI runs successfully
- [ ] Merge multiple PRs in quick succession to test concurrency handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)