### PR TITLE
feat: remove [board.cockpit] and use 12-column layout

### DIFF
--- a/etc/halos-homarr-branding/branding.toml
+++ b/etc/halos-homarr-branding/branding.toml
@@ -52,20 +52,11 @@ admin_password = "HalosAdmin123@"
 # Default board configuration
 name = "Halos"
 display_name = "Halos"
-column_count = 10
+column_count = 12
 is_public = true
 
-[board.cockpit]
-# Cockpit tile - always present on default board
-enabled = true
-name = "Cockpit"
-description = "System management console"
-href = "https://halos.local:9090"
-icon_url = "https://cockpit-project.org/images/site/cockpit-logo.svg"
-width = 2
-height = 2
-x_offset = 0
-y_offset = 0
+# NOTE: Cockpit is now configured via /etc/halos/webapps.d/cockpit.toml
+# The [board.cockpit] section has been removed in favor of the unified registry.
 
 [settings]
 # Server settings for first-boot initialization


### PR DESCRIPTION
## Summary

- Remove `[board.cockpit]` section from branding.toml
- Change `column_count` from 10 to 12 for better layout flexibility

## Changes

Cockpit is now registered via `/etc/halos/webapps.d/cockpit.toml` in the cockpit-branding-halos package instead of being hardcoded in the branding config.

The 12-column grid provides better divisibility (2, 3, 4, 6) for responsive layouts.

## Test plan

- [ ] Package builds successfully
- [ ] homarr-container-adapter reads updated branding.toml correctly
- [ ] Dashboard displays with 12-column layout

Related: hatlabs/homarr-container-adapter#22

🤖 Generated with [Claude Code](https://claude.com/claude-code)